### PR TITLE
fix: improve image display and remove scroll lag in about section

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -202,18 +202,15 @@ export default function Home() {
           />
           
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
-            <motion.div 
-              style={{ y: aboutY }}
-              className="relative w-full h-[400px] rounded-2xl overflow-hidden"
-            >
+            <div className="relative w-full h-[400px] rounded-2xl overflow-hidden">
               <Image
                 src="/profile.jpg" // Add your profile image to public folder
                 alt="Priyanshu"
                 fill
-                className="object-cover"
+                className="object-cover object-top"
                 sizes="(max-width: 768px) 100vw, 50vw"
               />
-            </motion.div>
+            </div>
             
             <div>
               <AnimatedText 


### PR DESCRIPTION
**Summary**

Fixed two issues with the profile image in the about me section:

- Removed parallax animation that was causing scrolling lag effects
- Changed image positioning to crop legs and focus on upper portion

**Changes**

- Removed `motion.div` wrapper and `style={{ y: aboutY }}` transform
- Changed from `object-cover` to `object-cover object-top` for better image positioning
- Maintained same container dimensions and styling

Resolves #2

🤖 Generated with [Claude Code](https://claude.ai/code)